### PR TITLE
Relax opentsdb version check to work with either 2.1.1 or 2.2.0

### DIFF
--- a/src/main/java/org/zenoss/lib/tsdb/OpenTsdbClient.java
+++ b/src/main/java/org/zenoss/lib/tsdb/OpenTsdbClient.java
@@ -105,7 +105,7 @@ public class OpenTsdbClient {
             } else {
                 line = null;
             }
-            if (line != null && !line.isEmpty() && !line.startsWith("net.opentsdb ") && !line.startsWith("Built on ")) {
+            if (line != null && !line.isEmpty() && !line.startsWith("net.opentsdb") && !line.startsWith("Built on ")) {
                 if (errors == null) {
                     errors = new ArrayList<String>();
                 }
@@ -138,7 +138,7 @@ public class OpenTsdbClient {
     public boolean isAlive() {
         try {
             String ver = version();
-            return ver.startsWith( "net.opentsdb ");
+            return ver.startsWith( "net.opentsdb");
         } catch (IOException ex) {
             return false;
         }

--- a/src/test/java/org/zenoss/lib/tsdb/OpenTsdbClientFactoryTest.java
+++ b/src/test/java/org/zenoss/lib/tsdb/OpenTsdbClientFactoryTest.java
@@ -50,15 +50,15 @@ public class OpenTsdbClientFactoryTest {
         when (socketFactory.newSocket (any (SocketAddress.class))).thenReturn(socket);
         
         OpenTsdbClientFactory factory = new OpenTsdbClientFactory(config(), socketFactory);
-        assertNotNull (factory.makeObject());
+        assertNotNull(factory.makeObject());
     }
     
     @Test
-    public void testBasicValidate() throws Exception {
+    public void testBasicValidateForOpentsdb211() throws Exception {
         Socket socket = mock(Socket.class);
         SocketFactory socketFactory = mock(SocketFactory.class);
         OutputStream os = mock(OutputStream.class);
-        InputStream is = new ByteArrayInputStream("net.opentsdb built at revision 1.2.3".getBytes(StandardCharsets.UTF_8));
+        InputStream is = new ByteArrayInputStream("net.opentsdb 2.1.1 built at revision 1.2.3".getBytes(StandardCharsets.UTF_8));
         when (socketFactory.newSocket (any (SocketAddress.class))).thenReturn(socket);
         
         OpenTsdbClientFactory factory = new OpenTsdbClientFactory(config(), socketFactory);
@@ -69,7 +69,24 @@ public class OpenTsdbClientFactoryTest {
 
         assertTrue(factory.validateObject(c1));
     }
-    
+
+    @Test
+    public void testBasicValidateForOpentsdb220() throws Exception {
+        Socket socket = mock(Socket.class);
+        SocketFactory socketFactory = mock(SocketFactory.class);
+        OutputStream os = mock(OutputStream.class);
+        InputStream is = new ByteArrayInputStream("net.opentsdb.tools 2.2.0 built at revision 1.2.3".getBytes(StandardCharsets.UTF_8));
+        when (socketFactory.newSocket (any (SocketAddress.class))).thenReturn(socket);
+
+        OpenTsdbClientFactory factory = new OpenTsdbClientFactory(config(), socketFactory);
+        OpenTsdbClient c1 = factory.makeObject();
+
+        when (socket.getOutputStream()).thenReturn(os);
+        when (socket.getInputStream()).thenReturn(is);
+
+        assertTrue(factory.validateObject(c1));
+    }
+
     @Test
     public void testReadError() throws Exception {
         Socket socket = mock(Socket.class);

--- a/src/test/java/org/zenoss/lib/tsdb/OpenTsdbClientTest.java
+++ b/src/test/java/org/zenoss/lib/tsdb/OpenTsdbClientTest.java
@@ -137,8 +137,21 @@ public class OpenTsdbClientTest {
     }
 
     @Test
-    public void testIsAlive() throws IOException {
-        final String response = "net.opentsdb built at revision \n";
+    public void testIsAlive211() throws IOException {
+        final String response = "net.opentsdb 2.1.1 built at revision \n";
+        doAnswer(new Answer() {
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                byte[] message = (byte[]) invocation.getArguments()[0];
+                System.arraycopy(response.getBytes(), 0, message, 0, response.length());
+                return response.getBytes().length;
+            }
+        }).when(input).read(any(byte[].class), anyInt(), anyInt());
+        assertTrue(client.isAlive());
+    }
+
+    @Test
+    public void testIsAlive220() throws IOException {
+        final String response = "net.opentsdb.tools 2.2.o built at revision \n";
         doAnswer(new Answer() {
             public Object answer(InvocationOnMock invocation) throws Throwable {
                 byte[] message = (byte[]) invocation.getArguments()[0];


### PR DESCRIPTION
Part of the fix for [ZEN-23199](https://jira.zenoss.com/browse/ZEN-23199).

The response from OpenTsdb for the `version` query changed from 2.1.1 to 2.2.0. The response from the newer version begins with `net.opentsdb.tools `. This change works with both.