### PR TITLE
ZEN-24550: do not convert all values to double.

### DIFF
--- a/src/main/java/org/zenoss/lib/tsdb/OpenTsdbClient.java
+++ b/src/main/java/org/zenoss/lib/tsdb/OpenTsdbClient.java
@@ -174,7 +174,16 @@ public class OpenTsdbClient {
         builder.append(" ");
         builder.append(timestamp);
         builder.append(" ");
-        builder.append(value);
+
+        // As of opentsdb 2.2 float values are stored on 4 bytes. Integers
+        // however are stored in 64 bits if needed. That is why if the 
+        // value has no decimals, we store it as an int. (ZEN-24550)
+        if (Math.ceil(value) == Math.floor(value)) {
+            builder.append((long)value);
+        }
+        else {
+            builder.append(value);
+        }
 
         // Sort the entries by key to guarantee their order.
         List<Map.Entry<String, String>> sortedTags = new LinkedList<>(tags.entrySet());

--- a/src/test/java/org/zenoss/lib/tsdb/OpenTsdbClientTest.java
+++ b/src/test/java/org/zenoss/lib/tsdb/OpenTsdbClientTest.java
@@ -83,22 +83,29 @@ public class OpenTsdbClientTest {
 
     @Test
     public void testPutSortsKeys() throws IOException {
-        final String expected = "put m 0 0.0 tag-alpha=zero tag-bravo=yankee tag-charlie=zulu\n";
+        final String expected = "put m 0 0.1 tag-alpha=zero tag-bravo=yankee tag-charlie=zulu\n";
         Map<String, String> tags1 = new HashMap<String, String>();
         tags1.put("tag-charlie", "zulu");
         tags1.put("tag-alpha", "zero");
         tags1.put("tag-bravo", "yankee");
-        final String message1 = OpenTsdbClient.toPutMessage("m", 0, 0.0, tags1);
+        final String message1 = OpenTsdbClient.toPutMessage("m", 0, 0.1, tags1);
 
         Map<String, String> tags2 = new HashMap<String, String>();
         tags2.put("tag-bravo", "yankee");
         tags2.put("tag-charlie", "zulu");
         tags2.put("tag-alpha", "zero");
-        final String message2 = OpenTsdbClient.toPutMessage("m", 0, 0.0, tags2);
+        final String message2 = OpenTsdbClient.toPutMessage("m", 0, 0.1, tags2);
+
+        // Values with no decimal part are stored as integers bc as of opentsdb 2.2
+        // float values are stored on 32 bits and integers can be stored in up to
+        // 64 bits depending ion how big the number is (ZEN-24550)
+        final String expected2 = "put m 0 10 tag-alpha=zero tag-bravo=yankee tag-charlie=zulu\n";
+        final String message3 = OpenTsdbClient.toPutMessage("m", 0, 10.0, tags2);
 
         assertEquals(expected, message1);
         assertEquals(expected, message2);
         assertEquals(message1, message2);
+        assertEquals(expected2, message3);
     }
 
 


### PR DESCRIPTION
As of opentsdb 2.2 float values are stored on 4 bytes. Integers however are stored in 64 bits if needed.
If the value has no decimals, we store it as an int to avoid precision loss in case the number needs 64 bits.